### PR TITLE
Updated posted_at method to return the time in the user's local time

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,8 +12,8 @@ class Post < ApplicationRecord
     all.reverse
   end
 
-  def posted_at
-    created_at.strftime("%H:%M (%d/%m/%y)")
+	def posted_at
+    created_at.localtime.strftime("%H:%M (%d/%m/%y)")
   end
 
   def summary


### PR DESCRIPTION
An update to the Post class method which returns the time a post was created. The post_at method previously returned the time one hour behind GMT, it has been updated to return the post time at the user's local time

<img width="480" alt="screen shot 2017-08-24 at 12 09 35" src="https://user-images.githubusercontent.com/9513073/29663866-26e96292-88c5-11e7-967a-ee9d9efb70d4.png">
. 