### PR TITLE
created migration for removing null

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,32 @@ Pull requests are automatically staged as 'review apps' on heroku and will be av
 
 ### https://acebook17.herokuapp.com
 Heroku automatically deploys master branch on github to production.
+
+### Database Issues
+Due to poor planning, features were pushed live without their associations (ie. 'commenting' without the 'user' association in the database). This caused issues when the association was added, as existing items in the database had NULL values in the foreign key column.
+In order to eliminate errors, a migration was written for populating the NULL values in the production database ([PR here](https://github.com/makersacademy/acebook-july2017/pull/28)).
+To test the migration effectively, the production database was duplicated, and the migration was run locally. The process was as follows:
+
+- Generate a backup of the database. This backup appears as a .dump in the current folder:
+```
+heroku pg:backups:capture
+```
+- Create a local database which we will populate from the .dump backup:
+```
+createdb acebook17-guineapig]
+```
+- Populate the database with the backup:
+```
+pg_restore -d acebook17-guineapig "latest.dump"
+```
+- Create a new environment in config environments (in this case; guineapig.rb)
+- Add the database to the environment (config/database.yml):
+```
+guineapig:
+  <<: *default
+  database: acebook17-guineapig
+```
+- run a migration using our new environment:
+```
+bin/rails db:migrate RAILS_ENV="guineapig"
+```

--- a/db/migrate/20170824111217_database_nil_exterminator.rb
+++ b/db/migrate/20170824111217_database_nil_exterminator.rb
@@ -1,0 +1,13 @@
+class DatabaseNilExterminator < ActiveRecord::Migration[5.1]
+  def change
+    execute "UPDATE likes SET user_id = '9' WHERE user_id IS NULL;"
+    execute "UPDATE posts SET user_id = '9' WHERE user_id IS NULL;"
+    execute "UPDATE comments SET user_id = '9' WHERE user_id IS NULL;"
+    execute "UPDATE users SET first_name = '[name]' WHERE first_name IS NULL;"
+    execute "UPDATE users SET last_name = '[lastname]' WHERE last_name IS NULL;"
+    execute "UPDATE users SET occupation = '[occupation]' WHERE occupation IS NULL;"
+    execute "UPDATE users SET hometown = '[hometown]' WHERE hometown IS NULL;"
+    execute "UPDATE users SET date_of_birth = '1970-01-01 00:00:00' WHERE date_of_birth IS NULL;"
+    execute "UPDATE users SET bio = '[bio]' WHERE bio IS NULL;"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170823152351) do
+ActiveRecord::Schema.define(version: 20170824111217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,7 +39,9 @@ ActiveRecord::Schema.define(version: 20170823152351) do
     t.bigint "post_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "likes", force: :cascade do |t|
@@ -57,10 +59,6 @@ ActiveRecord::Schema.define(version: 20170823152351) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
-  end
-
-  create_table "students", id: :serial, force: :cascade do |t|
-    t.string "name", limit: 50 
   end
 
   create_table "users", force: :cascade do |t|
@@ -87,6 +85,7 @@ ActiveRecord::Schema.define(version: 20170823152351) do
   end
 
   add_foreign_key "comments", "posts"
+  add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"


### PR DESCRIPTION
created a migration that when run will populate NULL values with specified defaults
(user with user_id = '9' is a placeholder user specially created on the production database)

The migration will:
- In 'users' table: set user_id = '9' where user_id is null
- In 'likes' table: set user_id = '9' where user_id is null
- In 'posts' table: set user_id = '9' where user_id is null
- In 'comments' table: set user_id = '9' where user_id is null
- In 'user' table: set first_name = '[name]' where first_name is null
- In 'user' table: set last_name = '[lastname]' where last_name is null
- In 'user' table: set occupation = '[occupation]' where occupation is null
- In 'user' table: set hometown = '[hometown]' where hometown is null
- In 'user' table: set date_of_birth = '1970-01-01 00:00:00' where date_of_birth is null
- In 'user' table: set bio = 'bio' where bio is null