### PR TITLE
Create post field

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,22 +1,18 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!
 
-  def new
-    @post = current_user.posts.new
-  end
-
   def create
     post = Post.new(post_params)
     current_user.posts << post
     current_user.save
     redirect_to posts_url
-
   end
 
   def index
     @posts = Post.reverse_order
     @comment = Comment.new
     @like = Like.new
+    @post = current_user.posts.new
   end
 
   private

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,3 +1,9 @@
+<%= form_for @post, url: {controller: "posts", action: "create"} do |form| %>
+  <%= form.label :message, "Create a new post" %>
+  <%= form.text_area :message, :rows =>4, :cols => 50 %>
+  <%= form.submit "Submit" %>
+<% end %>
+
 <% @posts.each do |post| %>
   <div id='post-<%= post.id %>' class="post">
     <div class="post__head">
@@ -24,14 +30,10 @@
       <% end %>
     </div>
     <%= form_for [post, @comment] do |form| %>
-      <%= form.label :message %>
+      <%= form.label :comment %>
       <%= form.text_area :message, :rows =>1, :cols => 50 %>
       <%= form.hidden_field :post_id, value: post.id %>
       <%= form.submit "Submit" %>
     <% end %>
 </div>
-<% end %>
-
-<%= link_to new_post_path do %>
-  New post
 <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,5 +1,0 @@
-<%= form_for @post do |form| %>
-  <%= form.label :message %>
-  <%= form.text_area :message, :rows =>4, :cols => 50 %>
-  <%= form.submit "Submit" %>
-<% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,10 +59,6 @@ ActiveRecord::Schema.define(version: 20170823152351) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
-  create_table "students", id: :serial, force: :cascade do |t|
-    t.string "name", limit: 50 
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -3,14 +3,9 @@ require 'rails_helper'
 RSpec.describe PostsController, type: :controller do
   describe "Post" do
     let!(:user) { create(:user) }
-    
+
     before do
       sign_in(user)
-    end
-
-    it "GET /new responds with 200" do
-      get :new
-      expect(response).to have_http_status(200)
     end
 
     it "POST / responds with 200" do

--- a/spec/features/likes-increases-when-like-button-is-clicked_spec.rb
+++ b/spec/features/likes-increases-when-like-button-is-clicked_spec.rb
@@ -12,8 +12,7 @@ RSpec.feature "Like", type: :feature do
       click_button 'Log in'
     end
     visit "/posts"
-    click_link "New post"
-    fill_in "Message", with: "Hello, world!"
+    fill_in "post_message", with: "Hello, world!"
     click_button "Submit"
   end
 

--- a/spec/features/page-does-not-change-when-button-is-clicked_spec.rb
+++ b/spec/features/page-does-not-change-when-button-is-clicked_spec.rb
@@ -11,8 +11,7 @@ RSpec.feature "Like", type: :feature do
       click_button 'Log in'
     end
     visit "/posts"
-    click_link "New post"
-    fill_in "Message", with: "Hello, world!"
+    fill_in "post_message", with: "Hello, world!"
     click_button "Submit"
   end
 

--- a/spec/features/posts-show-the-date-they-were-posted_spec.rb
+++ b/spec/features/posts-show-the-date-they-were-posted_spec.rb
@@ -15,8 +15,7 @@ RSpec.feature "Show Date", type: :feature do
 
   scenario "Newly created posts show the date they were posted" do
     visit "/posts"
-    click_link "New post"
-    fill_in "Message", with: "Hello, world!"
+    fill_in "post_message", with: "Hello, world!"
     click_button "Submit"
     post = Post.find_by(message: "Hello, world!")
     expect(page).to have_content(post.created_at.strftime("%H:%M (%d/%m/%y)"))

--- a/spec/features/user_can_submit_posts_spec.rb
+++ b/spec/features/user_can_submit_posts_spec.rb
@@ -11,17 +11,16 @@ RSpec.feature "Timeline", type: :feature do
       click_button 'Log in'
     end
     visit "/posts"
-    click_link "New post"
   end
 
   scenario "Can submit posts and view them" do
-    fill_in "Message", with: "Hello, world!"
+    fill_in "post_message", with: "Hello, world!"
     click_button "Submit"
     expect(page).to have_content("Hello, world!")
   end
 
   scenario "Can make posts with multpile lines" do
-    fill_in "Message", with: "Hey\r\nWhat's up\r"
+    fill_in "post_message", with: "Hey\r\nWhat's up\r"
     click_button "Submit"
     expect(page).to have_content("Hey\r\nWhat's up\r")
   end

--- a/spec/features/users_can_like_posts_only_once_spec.rb
+++ b/spec/features/users_can_like_posts_only_once_spec.rb
@@ -7,8 +7,7 @@ RSpec.feature "Like", type: :feature do
   before do
     login
     visit "/posts"
-    click_link "New post"
-    fill_in "Message", with: "Hello, world!"
+    fill_in "post_message", with: "Hello, world!"
     click_button "Submit"
   end
 


### PR DESCRIPTION
Changes the 'New post' link on the index page into a create post field in order to reduce the number of clicks a user must make to create a new post. Removed the post#new route.